### PR TITLE
Add juspay/neurolink to Programming Frameworks for LLMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -664,6 +664,7 @@ In essence, Generative AI is about feeding an AI system vast amounts of data, tr
 
 ### Programming Frameworks for LLMs
 
+* [juspay/neurolink](https://github.com/juspay/neurolink): TypeScript-first AI SDK with provider-agnostic routing across 13 providers (OpenAI, Anthropic, Gemini, and more), built-in RAG pipelines, MCP client integration, and OpenTelemetry observability.
 * [DSPy: Not Your Average Prompt Engineering](https://jina.ai/news/dspy-not-your-average-prompt-engineering/): a post about the DSPy, a framework developed by the Stanford NLP group aimed at algorithmically optimizing language model prompts
 * [🔥🔥🔥] [stanfordnlp/dspy](https://github.com/stanfordnlp/dspy): DSPy: The framework for programming — not prompting — foundation models
 


### PR DESCRIPTION
Hi! Proposing to add **NeuroLink** to the Programming Frameworks for LLMs section.

NeuroLink is a TypeScript-first AI SDK for building production AI applications:
- Provider-agnostic routing across 13 providers (OpenAI, Anthropic, Google, AWS Bedrock, Mistral, and more)
- Built-in RAG pipeline with 10 chunking strategies, hybrid search, and reranking
- MCP client integration (58+ external servers via stdio/HTTP/SSE/WebSocket)
- OpenTelemetry observability with AI-specific metrics
- MIT licensed, TypeScript 5.0+

GitHub: https://github.com/juspay/neurolink