### PR TITLE
Add OpenCodex (iPhone remote Codex client)

### DIFF
--- a/README.md
+++ b/README.md
@@ -489,6 +489,7 @@ In essence, Generative AI is about feeding an AI system vast amounts of data, tr
 
 ## Vibe Coding
 
+* [OpenCodex](https://github.com/mjmkk/opencodex): Run Codex on your Mac from iPhone (self-hosted). Chat, command approval, file browser, and remote terminal (Tailscale friendly).
 * [filipecalegario/awesome-vibe-coding](https://github.com/filipecalegario/awesome-vibe-coding): A curated list of vibe coding references, colaborating with AI to write code.
 * [Andrej Karpathy on X](https://x.com/karpathy/status/1886192184808149383): "There's a new kind of coding I call "vibe coding", where you fully give in to the vibes, embrace exponentials, and forget that the code even exists."
 * [Windsurf Editor by Codeium](https://codeium.com/windsurf): agentic IDE, "where the work of developers and AI truly flow together, allowing for a coding experience that feels like literal magic"


### PR DESCRIPTION
Hi! This PR adds OpenCodex to the **Vibe Coding** section.\n\n- Kept the required format: link + colon + short description\n- Added the new entry at the top of the section list (reverse chronological order)\n\nOpenCodex is an iOS client + local worker backend that lets you run Codex on your Mac from your iPhone (self-hosted), with chat, command approval, file browser, and remote terminal (Tailscale friendly).\n\nThanks!