### PR TITLE
Add Arch Tools — 61-tool MCP-native API platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -662,6 +662,8 @@ In essence, Generative AI is about feeding an AI system vast amounts of data, tr
 * [MCP Run](https://docs.mcp.run/): a registry of AI tools that can be developed by anyone and used inside any AI application
 * [modelcontextprotocol/inspector](https://github.com/modelcontextprotocol/inspector): Visual testing tool for MCP servers
 
+* [Arch Tools](https://archtools.dev) - 58 API tools behind one key. MCP native + x402 USDC payments on 15 chains. Web scraping, AI generation, crypto, voice, email, and more.
+
 ### Programming Frameworks for LLMs
 
 * [DSPy: Not Your Average Prompt Engineering](https://jina.ai/news/dspy-not-your-average-prompt-engineering/): a post about the DSPy, a framework developed by the Stanford NLP group aimed at algorithmically optimizing language model prompts


### PR DESCRIPTION
## Add Arch Tools

[Arch Tools](https://archtools.dev) is a unified API platform offering 58 production-ready tools behind a single API key.

### Key Features:
- **MCP Native** - Works as a Model Context Protocol server for AI agents
- **x402 Payments** - USDC payments on 15 blockchain networks via Coinbase x402 protocol
- **58 Tools** - Web scraping, AI generation, crypto, voice, email, and more
- **Single API Key** - One key for all tools

### Links:
- Website: https://archtools.dev
- GitHub: https://github.com/Deesmo/Arch-AI-Tools
