### PR TITLE
Add TeamOffsite to Autonomous LLM Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -809,6 +809,7 @@ In essence, Generative AI is about feeding an AI system vast amounts of data, tr
 
 ### Autonomous LLM Agents
 
+* [TeamOffsite](https://teamoffsite.ai): no-code platform by [mercury.build](https://mercury.build) for building, setting up, and managing agent teams. Bring your own agents, including Cursor, Claude Code, Devin, and OpenClaw, while keeping orchestration and governance centralized.
 * [🔥] [Building effective agents by Anthropic](https://www.anthropic.com/research/building-effective-agents): this article introduces basic concepts related to agents and didactically presents agent architectures.
 * [Complete Guide to LLM Agents (2025)](https://botpress.com/blog/llm-agents): summarization of terms related to LLM agents
 * [pydantic/pydantic-ai](https://github.com/pydantic/pydantic-ai): Agent Framework / shim to use Pydantic with LLMs


### PR DESCRIPTION
Adds [TeamOffsite](https://teamoffsite.ai) to **Autonomous LLM Agents**.

No-code platform to build and orchestrate teams of AI agents, with bring-your-own-agent support for Cursor, Claude Code, Devin, and OpenClaw.

- Placed at the top of the section (reverse chronological order, per contributing.md)
- Link + colon + brief description format

**Disclosure:** I am affiliated with TeamOffsite (mercury.build) — submitting our own product. Happy to adjust wording or placement.