### PR TITLE
feat: add TWZRD Agent Intel to Model Context Protocol section

### DIFF
--- a/README.md
+++ b/README.md
@@ -661,6 +661,7 @@ In essence, Generative AI is about feeding an AI system vast amounts of data, tr
 * [loopwork-ai/emcee](https://github.com/loopwork-ai/emcee): a tool that provides a Model Context Protocol (MCP) server for any web application with an OpenAPI specification.
 * [MCP Run](https://docs.mcp.run/): a registry of AI tools that can be developed by anyone and used inside any AI application
 * [modelcontextprotocol/inspector](https://github.com/modelcontextprotocol/inspector): Visual testing tool for MCP servers
+* [TWZRD Agent Intel](https://intel.twzrd.xyz): Trust-scoring MCP server for x402 payment agents on Solana — free preflight check + signed V5 trust receipt via USDC micropayment (<1s settlement). Tools: `resolve_agent`, `score_agent`, `get_trust_receipt`, `verify_trust_receipt`. [MCP endpoint](https://intel.twzrd.xyz/mcp)
 
 ### Programming Frameworks for LLMs
 


### PR DESCRIPTION
## What

Adds **[TWZRD Agent Intel](https://intel.twzrd.xyz)** to the **List of Servers** in the Model Context Protocol section.

## About the entry

TWZRD Agent Intel is a production MCP server providing trust scoring for autonomous payment agents on Solana. It exposes the [x402 payment protocol](https://x402.org/) to MCP clients and is registered at `registry.modelcontextprotocol.io` as `xyz.twzrd.intel/twzrd-agent-intel v0.1.2`.

- **MCP endpoint**: https://intel.twzrd.xyz/mcp (Streamable-HTTP)
- **Tools**: `resolve_agent`, `score_agent`, `get_trust_receipt`, `verify_trust_receipt`
- **GitHub**: 
- **Registry**: https://registry.modelcontextprotocol.io

## Why it fits

The entry is placed in "List of Servers" alongside existing MCP server listings (punkpeye/awesome-mcp-servers, composio MCP, etc.), consistent with this section's purpose.