### PR TITLE
Add AIFast Hub to Online Tools and Applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,6 +436,8 @@ In essence, Generative AI is about feeding an AI system vast amounts of data, tr
 
 ## Online Tools and Applications
 
+* [AIFast Hub](https://www.aifast.club/): OpenAI-compatible API access to models listed in its current catalog; availability should be checked in the console and maintenance notices.
+
 * [Lunroo](https://lunroo.com): 45+ Free AI Tools for Social Media Marketing. Save your time on routine tasks using AI.
 * [COUNT](https://getcount.com): AI-powered accounting for small businesses
 * [Competitor Research](https://www.competitoresearch.com): AI tool to help companies track their competitors


### PR DESCRIPTION
## Summary

Adds one minimal AIFast Hub entry to the existing Online Tools and Applications list.

## Scope

- one README list entry only;
- no fixed model count or model-version claim;
- no latency, uptime, pricing, availability, or network-access claim;
- links use https://www.aifast.club.