### PR TITLE
Add AI Fast Club to Large Language Models

### DIFF
--- a/README.md
+++ b/README.md
@@ -561,6 +561,7 @@ In essence, Generative AI is about feeding an AI system vast amounts of data, tr
 * [mendableai/firecrawl](https://github.com/mendableai/firecrawl): Turn entire websites into LLM-ready markdown or structured data. Scrape, crawl and extract with a single API.
 * [QuivrHQ/MegaParse](https://github.com/quivrhq/megaparse): File Parser optimised for LLM Ingestion with no loss. Parse PDFs, Docx, PPTx in a format that is ideal for LLMs.
 * [LiteLLM](https://www.litellm.ai/): a proxy server to manage auth, loadbalancing, and spend tracking across 100+ LLMs, all in the OpenAI format
+* [AI Fast Club](https://www.aifast.club/): unified API platform providing OpenAI-compatible access to Claude, OpenAI, Gemini, Grok, DeepSeek, Qwen, Kimi and 570+ other LLMs, with domestic Chinese payment support
 * [youssefHosni/Hands-On-LangChain-for-LLM-Applications-Development](https://github.com/youssefHosni/Hands-On-LangChain-for-LLM-Applications-Development): Practical LangChain tutorials for LLM applications development
 * [unclecode/crawl4ai: Crawl4AI](https://github.com/unclecode/crawl4ai): Open-source LLM Friendly Web Crawler & Scrapper
 * [microsoft/LMOps](https://github.com/microsoft/LMOps): General technology for enabling AI capabilities w/ LLMs and MLLMs

--- a/README.md
+++ b/README.md
@@ -561,7 +561,7 @@ In essence, Generative AI is about feeding an AI system vast amounts of data, tr
 * [mendableai/firecrawl](https://github.com/mendableai/firecrawl): Turn entire websites into LLM-ready markdown or structured data. Scrape, crawl and extract with a single API.
 * [QuivrHQ/MegaParse](https://github.com/quivrhq/megaparse): File Parser optimised for LLM Ingestion with no loss. Parse PDFs, Docx, PPTx in a format that is ideal for LLMs.
 * [LiteLLM](https://www.litellm.ai/): a proxy server to manage auth, loadbalancing, and spend tracking across 100+ LLMs, all in the OpenAI format
-* [AI Fast Club](https://www.aifast.club/): unified API platform providing OpenAI-compatible access to Claude, OpenAI, Gemini, Grok, DeepSeek, Qwen, Kimi and 570+ other LLMs, with domestic Chinese payment support
+* [AI Fast Club](https://www.aifast.club/): unified API platform providing OpenAI-compatible access to 500+ global and Chinese models, including Claude, GPT, Gemini, Grok, DeepSeek, Qwen, and Kimi, with Alipay/WeChat payment support
 * [youssefHosni/Hands-On-LangChain-for-LLM-Applications-Development](https://github.com/youssefHosni/Hands-On-LangChain-for-LLM-Applications-Development): Practical LangChain tutorials for LLM applications development
 * [unclecode/crawl4ai: Crawl4AI](https://github.com/unclecode/crawl4ai): Open-source LLM Friendly Web Crawler & Scrapper
 * [microsoft/LMOps](https://github.com/microsoft/LMOps): General technology for enabling AI capabilities w/ LLMs and MLLMs


### PR DESCRIPTION
Adds **AI Fast Club** to the Large Language Models section.\n\nAI Fast Club is a unified API platform providing OpenAI-compatible access to 500+ global and Chinese models, including Claude, GPT, Gemini, Grok, DeepSeek, Qwen, and Kimi. It supports Alipay and WeChat payments.\n\nThis PR changes one file and adds one list entry following the existing format.